### PR TITLE
JSON export for jobs

### DIFF
--- a/src/IO.go
+++ b/src/IO.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -20,12 +19,6 @@ func formatAndPrint(planets []Planet, opts *Opts, writer io.Writer) {
 	log.Debugf("using formatter of type : %T", formatter)
 	formatter.init()
 	formatter.format(planets, opts, writer)
-
-	for _, entry := range planets {
-		if entry.outputStruct.errored {
-			os.Exit(1)
-		}
-	}
 }
 
 func printUnformatted(planets []Planet, writer io.Writer) {

--- a/src/JSONHandler.go
+++ b/src/JSONHandler.go
@@ -2,9 +2,36 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 )
+
+// JSONReport - The true output of a deeply disturbed,
+// incurably depressed and manically suicidal program named ski.
+type JSONReport struct {
+	Meta    Opts            `json:"meta,omitempty"`
+	Planets []PlanetWrapper `json:"planets"`
+}
+
+// PlanetWrapper ...
+type PlanetWrapper struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	User       string `json:"user"`
+	Host       string `json:"host"`
+	PlanetType string `json:"planet_type"`
+	DbID       string `json:"db_id"`
+	Valid      bool   `json:"valid"`
+	Output     string `json:"output"`
+	Index      int    `json:"index"`
+	Errored    bool   `json:"errored"`
+}
 
 func decode(jsonObject string) ([][]string, error) {
 	var jsonBlob = []byte(jsonObject)
@@ -15,4 +42,63 @@ func decode(jsonObject string) ([][]string, error) {
 		return make([][]string, 0), err
 	}
 	return toReturn, nil
+}
+
+func writeResultAsJSON(planets []Planet, opts *Opts, writer io.Writer) {
+	allInOne := JSONReport{}
+	allInOne.Planets = make([]PlanetWrapper, len(planets))
+	allInOne.Meta = *opts
+	for i, planet := range planets {
+		wrapper := PlanetWrapper{
+			ID:         planet.id,
+			Name:       planet.name,
+			User:       planet.user,
+			Host:       planet.host,
+			PlanetType: planet.planetType,
+			DbID:       planet.dbID,
+			Valid:      planet.valid,
+			Output:     planet.outputStruct.output,
+			Index:      i,
+			Errored:    planet.outputStruct.errored,
+		}
+		allInOne.Planets[i] = wrapper
+	}
+
+	json, err := json.MarshalIndent(allInOne, "", "    ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling the output as json %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Non json %v\n", allInOne)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(writer, "%s\n", json)
+}
+
+// creates a task from a json file
+func createATaskFromJobFile(jsonFile string) (opts Opts) {
+	job := Opts{}
+	wcopy := jsonFile // assumption abs path
+	tokens := strings.Split(jsonFile, string(os.PathSeparator))
+
+	if len(tokens) == 1 {
+		// relative path given, read from jobs folder
+		wcopy = path.Join(os.Getenv("ORBIT_HOME"), "jobs", jsonFile)
+	}
+	var err error
+	var bytes []byte
+	if bytes, err = ioutil.ReadFile(wcopy); err != nil {
+		errorMessage := fmt.Sprintf("%s : %s", err.Error(), jsonFile)
+		fmt.Fprint(os.Stderr, errorMessage)
+		log.Fatal(errorMessage)
+	}
+
+	if json.Unmarshal(bytes, &job); err != nil {
+		errorMessage := fmt.Sprintf("%s : %s", err.Error(), jsonFile)
+		fmt.Fprint(os.Stderr, errorMessage)
+		log.Fatal(errorMessage)
+	}
+
+	log.Debugf("Read a task from %s:", jsonFile)
+	log.Debugf("Unmarshalled %v", job)
+	return job
 }

--- a/src/JSONHandler_test.go
+++ b/src/JSONHandler_test.go
@@ -33,7 +33,7 @@ func TestWriteResultAsJSON(t *testing.T) {
 	var err error
 	jobFile := "job.js"
 	// Setup
-	name := "cron_jobs"
+	name := "jobs_output"
 	backup := os.Getenv("ORBIT_HOME")
 	os.Setenv("ORBIT_HOME", os.TempDir())
 
@@ -134,7 +134,7 @@ func TestCreateJSONReport(t *testing.T) {
 	options := map[string]string{}
 	options["job_name"] = path.Base(jobFile)
 	options["orbit_home"] = os.Getenv("ORBIT_HOME")
-	options["output"] = "cron_jobs"
+	options["output"] = "jobs_output"
 
 	planet := Planet{
 		id:         "app",

--- a/src/JSONHandler_test.go
+++ b/src/JSONHandler_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestDecode(t *testing.T) {
+	victim := "[[\"1\"], [\"2\"]]"
+	decoded, err := decode(victim)
+	if err != nil {
+		t.Fail()
+	}
+	for i, str := range decoded {
+		fmt.Printf("decoded[%d] %v\n", i, str)
+	}
+	if decoded[0][0] != "1" {
+		t.Fail()
+	}
+	if decoded[1][0] != "2" {
+		t.Fail()
+	}
+}
+
+func TestWriteResultAsJSON(t *testing.T) {
+	var outDir string
+	var err error
+	jobFile := "job.js"
+	// Setup
+	name := "cron_jobs"
+	backup := os.Getenv("ORBIT_HOME")
+	os.Setenv("ORBIT_HOME", os.TempDir())
+
+	if outDir, err = ioutil.TempDir(os.TempDir(), name); err != nil {
+		t.Fail()
+	}
+
+	planet := Planet{
+		id:         "app",
+		name:       "App-Package 1",
+		user:       "none",
+		host:       "localhost",
+		planetType: "server",
+		dbID:       "",
+		valid:      true,
+		outputStruct: &StructuredOuput{
+			planet:   "app",
+			output:   "exit status 2",
+			table:    nil,
+			position: 0,
+			errored:  true,
+		},
+	}
+	planets := []Planet{planet}
+
+	// "-j=/tmp/job.js", "-t=\"perlver_template\"", "-p", "-d=true", "app"
+	opts := Opts{
+		Template: "perlver_template",
+		Pretty:   true,
+		Debug:    true,
+		Planets:  []string{"app"},
+	}
+
+	basename := path.Base(jobFile)
+	fileToWrite := path.Join(outDir, basename)
+	if writer, err := os.Create(fileToWrite); err != nil {
+		t.Fail()
+	} else {
+		defer writer.Close()
+		writeResultAsJSON(planets, &opts, writer)
+		// Check if the content of the json is okay.
+		var bytes []byte
+		if bytes, err = ioutil.ReadFile(fileToWrite); err != nil {
+			t.Fail()
+		} else {
+			allInOne := JSONReport{}
+			if err := json.Unmarshal(bytes, &allInOne); err != nil {
+				t.Fail()
+			} else {
+				if allInOne.Planets[0].ID != planet.id {
+					t.Fail()
+				}
+				if allInOne.Planets[0].Name != planet.name {
+					t.Fail()
+				}
+				if allInOne.Planets[0].User != planet.user {
+					t.Fail()
+				}
+				if allInOne.Planets[0].Host != planet.host {
+					t.Fail()
+				}
+				if allInOne.Planets[0].PlanetType != planet.planetType {
+					t.Fail()
+				}
+				if allInOne.Planets[0].DbID != planet.dbID {
+					t.Fail()
+				}
+				if allInOne.Planets[0].Valid != planet.valid {
+					t.Fail()
+				}
+				if allInOne.Planets[0].Output != planet.outputStruct.output {
+					t.Fail()
+				}
+				if allInOne.Planets[0].Index != planet.outputStruct.position {
+					t.Fail()
+				}
+				if allInOne.Planets[0].Errored != planet.outputStruct.errored {
+					t.Fail()
+				}
+			}
+		}
+	}
+
+	// Tear down
+	defer func() {
+		os.Setenv("ORBIT_HOME", backup)
+		os.RemoveAll(outDir)
+	}()
+}

--- a/src/JSONHandler_test.go
+++ b/src/JSONHandler_test.go
@@ -6,7 +6,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestDecode(t *testing.T) {
@@ -120,4 +122,92 @@ func TestWriteResultAsJSON(t *testing.T) {
 		os.Setenv("ORBIT_HOME", backup)
 		os.RemoveAll(outDir)
 	}()
+}
+
+// func createJSONReport(options map[string]string, planets []Planet, opts *Opts)
+func TestCreateJSONReport(t *testing.T) {
+	// Setup
+	jobFile := "job.js"
+	backup := os.Getenv("ORBIT_HOME")
+	os.Setenv("ORBIT_HOME", os.TempDir())
+
+	options := map[string]string{}
+	options["job_name"] = path.Base(jobFile)
+	options["orbit_home"] = os.Getenv("ORBIT_HOME")
+	options["output"] = "cron_jobs"
+
+	planet := Planet{
+		id:         "app",
+		name:       "App-Package 1",
+		user:       "none",
+		host:       "localhost",
+		planetType: "server",
+		dbID:       "",
+		valid:      true,
+		outputStruct: &StructuredOuput{
+			planet:   "app",
+			output:   "exit status 2",
+			table:    nil,
+			position: 0,
+			errored:  true,
+		},
+	}
+	planets := []Planet{planet}
+
+	// "-j=/tmp/job.js", "-t=\"perlver_template\"", "-p", "-d=true", "app"
+	opts := Opts{
+		Template: "perlver_template",
+		Pretty:   true,
+		Debug:    true,
+		Planets:  []string{"app"},
+	}
+
+	createJSONReport(options, planets, &opts)
+	// Check if the content of the json is okay.
+	jobName := strings.Split(options["job_name"], ".")[0]
+	// ${ORBIT_HOME/cron_jobs/job/${timestamp_in_iso8601 with : replaced with _ }.json
+	outputFolder := path.Join(options["orbit_home"], options["output"], jobName)
+	fileToWrite := findLatest(outputFolder)
+	fmt.Printf("Attempting to unmarshal JSONReport from %s\n", fileToWrite)
+	var bytes []byte
+	var err error
+	if bytes, err = ioutil.ReadFile(fileToWrite); err == nil {
+		report := JSONReport{}
+		if err = json.Unmarshal(bytes, &report); err == nil {
+			wrapper := report.Planets[0]
+			if wrapper.ID != planet.id ||
+				wrapper.Name != planet.name ||
+				wrapper.User != planet.user ||
+				wrapper.Host != planet.host ||
+				wrapper.PlanetType != planet.planetType ||
+				wrapper.DbID != planet.dbID ||
+				wrapper.Valid != planet.valid ||
+				wrapper.Output != planet.outputStruct.output ||
+				wrapper.Index != planet.outputStruct.position ||
+				wrapper.Errored != planet.outputStruct.errored {
+				fmt.Fprintln(os.Stderr, "Unmarshalled object contains wrong values.")
+				t.Fail()
+			}
+		}
+	}
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		t.Fail()
+	}
+
+	// Tear down
+	defer func() {
+		os.Setenv("ORBIT_HOME", backup)
+	}()
+}
+
+// Just a test function
+func findLatest(outputFolder string) string {
+	now := time.Now()
+	format := "%d-%02d-%02dT%02d_%02d_%02d"
+	stamp := fmt.Sprintf(format, now.Year(), now.Month(), now.Day(),
+		now.Hour(), now.Minute(), now.Second())
+	fileToWrite := strings.Join([]string{stamp, "json"}, ".")
+	return path.Join(outputFolder, fileToWrite)
 }

--- a/src/OptParser.go
+++ b/src/OptParser.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -109,35 +107,4 @@ func (opts *Opts) validateTemplate() {
 			log.Fatal(message)
 		}
 	}
-
-}
-
-// creates a task from a json file
-func createATaskFromJobFile(jsonFile string) (opts Opts) {
-	job := Opts{}
-	wcopy := jsonFile // assumption abs path
-	tokens := strings.Split(jsonFile, string(os.PathSeparator))
-	if len(tokens) == 1 {
-		// relative path given, read from jobs folder
-		wcopy = path.Join(os.Getenv("ORBIT_HOME"), "jobs", jsonFile)
-	}
-	bytes, err := ioutil.ReadFile(wcopy)
-	if err != nil {
-		errorMessage := fmt.Sprintf("Couldn't open job file: %s", jsonFile)
-		fmt.Fprint(os.Stderr, errorMessage)
-		log.Fatal(errorMessage)
-	}
-
-	err = json.Unmarshal(bytes, &job)
-	if err != nil {
-		errorMessage := fmt.Sprintf("Error parsing job json file: %s", jsonFile)
-		fmt.Fprint(os.Stderr, errorMessage)
-		log.Fatal(errorMessage)
-	}
-
-	log.Debugf("Read a task from %s", jsonFile)
-	log.Debugln()
-	log.Debugf("Unmarshalled %v", job)
-	log.Debugln()
-	return job
 }

--- a/src/ski.go
+++ b/src/ski.go
@@ -27,18 +27,15 @@ func main() {
 	exec.execMain(&opts)
 	if len(jobFile) == 0 {
 		formatAndPrint(exec.planets, &opts, os.Stdout)
-	} else {
-		basename := path.Base(jobFile)
-		home := os.Getenv("ORBIT_HOME")
-		const reports = "cron_jobs"
-		if writer, err := os.Create(path.Join(home, reports, basename)); err == nil {
-			writeResultAsJSON(exec.planets, &opts, writer)
-		} else {
-			log.Errorf("Could not create json output for the job %s", basename)
-			os.Exit(1)
-		}
+		handleExitCode(exec.planets)
+		return
 	}
-	handleExitCode(exec.planets)
+	options := map[string]string{}
+	options["job_name"] = path.Base(jobFile)
+	options["orbit_home"] = os.Getenv("ORBIT_HOME")
+	options["output"] = "cron_jobs"
+
+	createJSONReport(options, exec.planets, &opts)
 }
 
 // if there were any errors during the execution of command or scripts

--- a/src/ski.go
+++ b/src/ski.go
@@ -4,10 +4,14 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 )
+
+var help, pretty, debug, load, _version, saveReport bool
+var jobFile, logFile, template, scriptName, command string
 
 func main() {
 	opts := parseOptions()
@@ -22,7 +26,31 @@ func main() {
 	exec := makeExecutor(&opts)
 	exec.execMain(&opts)
 	formatAndPrint(exec.planets, &opts, os.Stdout)
-	log.Infof("Ended with args: %v", os.Args)
+	if len(jobFile) > 0 {
+		basename := path.Base(jobFile)
+		home := os.Getenv("ORBIT_HOME")
+		const reports = "cron_jobs"
+		if writer, err := os.Create(path.Join(home, reports, basename)); err == nil {
+			writeResultAsJSON(exec.planets, &opts, writer)
+		} else {
+			log.Errorf("Could not create json output for the job %s", basename)
+			os.Exit(1)
+		}
+	}
+	handleExitCode(exec.planets)
+}
+
+// if there were any errors during the execution of command or scripts
+// on any of the planets given as parameter, the exit code is set to non zero
+// in case other programs rely on the exit code.
+func handleExitCode(planets []Planet) {
+	for _, entry := range planets {
+		structuralError := entry.outputStruct == nil
+		executionFailure := entry.outputStruct.errored
+		if structuralError || executionFailure {
+			os.Exit(1)
+		}
+	}
 }
 
 func makeExecutor(opts *Opts) Executor {
@@ -67,9 +95,6 @@ func printUsage() {
 }
 
 func parseOptions() Opts {
-	var help, pretty, debug, load, _version, saveReport bool
-	var jobFile, logFile, template, scriptName, command string
-
 	flag.BoolVar(&help, "h", false, "help")
 	flag.BoolVar(&pretty, "p", false, "prettyprint")
 	flag.BoolVar(&debug, "d", false, "verbose")

--- a/src/ski.go
+++ b/src/ski.go
@@ -25,8 +25,9 @@ func main() {
 	log.Debug(&opts)
 	exec := makeExecutor(&opts)
 	exec.execMain(&opts)
-	formatAndPrint(exec.planets, &opts, os.Stdout)
-	if len(jobFile) > 0 {
+	if len(jobFile) == 0 {
+		formatAndPrint(exec.planets, &opts, os.Stdout)
+	} else {
 		basename := path.Base(jobFile)
 		home := os.Getenv("ORBIT_HOME")
 		const reports = "cron_jobs"

--- a/src/ski.go
+++ b/src/ski.go
@@ -33,7 +33,7 @@ func main() {
 	options := map[string]string{}
 	options["job_name"] = path.Base(jobFile)
 	options["orbit_home"] = os.Getenv("ORBIT_HOME")
-	options["output"] = "cron_jobs"
+	options["output"] = "jobs_output"
 
 	createJSONReport(options, exec.planets, &opts)
 }

--- a/src/ski_test.go
+++ b/src/ski_test.go
@@ -10,11 +10,15 @@ import (
 // the ones given as cmdline args
 func TestParseOptions(t *testing.T) {
 	// create the json file in tmp folder
-	jsonFile := setupOptParserTest()
+	jsonFile, err := setupOptParserTest()
+	if err != nil {
+		t.Fail()
+	}
 	jobOption := fmt.Sprintf("-j=%s", jsonFile)
 	os.Args = []string{"ski", jobOption, "-d=false", "-v=false", "-c=\"ls -la ${HOME}\""}
 	fmt.Printf("TestParseOptions :: os.Args: %v\n", os.Args)
 	opts := parseOptions()
+
 	fmt.Printf("TestParseOptions :: opts: %s\n", opts.String())
 
 	errors := make([]string, 0)
@@ -24,7 +28,7 @@ func TestParseOptions(t *testing.T) {
 	if opts.Version {
 		errors = append(errors, "Version flag set through the cmdline option.")
 	}
-	if opts.Command != "whatever" {
+	if opts.Command != "" {
 		msg := fmt.Sprintf("Command was not parsed correctly: %s", opts.Command)
 		errors = append(errors, msg)
 	}


### PR DESCRIPTION
 - IO.go: created a function for the exit code handling block and moved it to ski.go
 - OptParser.go & JSONHandler.go: createATaskFromJobFile function moved from OptParser to JSONHandler.go
 - JSONHandler.go: JSONReport & PlanetWrappere structs and writeResultAsJSON function created for JSON export.
 - JSONHandler_test.go: tests for decode and writeResultAsJSON
 - ski.go: Refactoring. If a task was given as a job file write the report as a json file in ${ORBIT_HOME}/cron_jobs with the same name as the name of the job file.