### PR TITLE
Ticket 43

### DIFF
--- a/src/Constants.go
+++ b/src/Constants.go
@@ -20,3 +20,4 @@ const linux = "linux"
 const mac = "darwin"
 const dbCommand = ". profiles/%s.prof && pqdb_sql.out -x -s %s ~/sql/%s"
 const fifaTokenCount = 5
+const jobExt = ".json"

--- a/src/JSONHandler.go
+++ b/src/JSONHandler.go
@@ -22,16 +22,12 @@ type JSONReport struct {
 
 // PlanetWrapper ...
 type PlanetWrapper struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	User       string `json:"user"`
-	Host       string `json:"host"`
-	PlanetType string `json:"planet_type"`
-	DbID       string `json:"db_id"`
-	Valid      bool   `json:"valid"`
-	Output     string `json:"output"`
-	Index      int    `json:"index"`
-	Errored    bool   `json:"errored"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Valid     bool   `json:"valid"`
+	Output    string `json:"output"`
+	Errored   bool   `json:"errored"`
+	CreatedAt string `json:"created_at"`
 }
 
 func decode(jsonObject string) ([][]string, error) {
@@ -51,17 +47,14 @@ func writeResultAsJSON(planets []Planet, opts *Opts, writer io.Writer) {
 	allInOne.Meta = *opts
 	for i, planet := range planets {
 		wrapper := PlanetWrapper{
-			ID:         planet.id,
-			Name:       planet.name,
-			User:       planet.user,
-			Host:       planet.host,
-			PlanetType: planet.planetType,
-			DbID:       planet.dbID,
-			Valid:      planet.valid,
-			Output:     planet.outputStruct.output,
-			Index:      i,
-			Errored:    planet.outputStruct.errored,
+			ID:      planet.id,
+			Name:    planet.name,
+			Output:  planet.outputStruct.output,
+			Errored: planet.outputStruct.errored,
+			// RFC3339 is a subset of ISO 8601
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
 		}
+
 		allInOne.Planets[i] = wrapper
 	}
 
@@ -95,8 +88,7 @@ func createJSONReport(options map[string]string, planets []Planet, opts *Opts) {
 	format := "%d-%02d-%02dT%02d_%02d_%02d"
 	stamp := fmt.Sprintf(format, now.Year(), now.Month(), now.Day(),
 		now.Hour(), now.Minute(), now.Second())
-	fileToWrite := strings.Join([]string{stamp, "json"}, ".")
-	toCreate := path.Join(folders, fileToWrite)
+	toCreate := path.Join(folders, fmt.Sprintf(`%s%s`, stamp, jobExt))
 
 	if writer, err := os.Create(toCreate); err == nil {
 		defer writer.Close()
@@ -133,24 +125,30 @@ func removeOldOutput(dir string, maxToKeep int) {
 func createATaskFromJobFile(jsonFile string) (opts Opts) {
 	job := Opts{}
 	wcopy := jsonFile // assumption abs path
-	tokens := strings.Split(jsonFile, string(os.PathSeparator))
+	parentDir, basename := path.Split(jsonFile)
 
-	if len(tokens) == 1 {
+	if len(parentDir) == 0 {
 		// relative path given, read from jobs folder
 		wcopy = path.Join(os.Getenv("ORBIT_HOME"), "jobs", jsonFile)
 	}
+
+	tokens := strings.Split(basename, ".")
+	if len(tokens) == 1 {
+		wcopy = fmt.Sprintf(`%s%s`, wcopy, jobExt)
+	}
+
 	var err error
 	var bytes []byte
 	if bytes, err = ioutil.ReadFile(wcopy); err != nil {
-		errorMessage := fmt.Sprintf("%s : %s", err.Error(), jsonFile)
-		fmt.Fprint(os.Stderr, errorMessage)
-		log.Fatal(errorMessage)
+		msg := fmt.Sprintf("%s : %s", err.Error(), jsonFile)
+		fmt.Fprint(os.Stderr, msg)
+		log.Fatal(msg)
 	}
 
 	if json.Unmarshal(bytes, &job); err != nil {
-		errorMessage := fmt.Sprintf("%s : %s", err.Error(), jsonFile)
-		fmt.Fprint(os.Stderr, errorMessage)
-		log.Fatal(errorMessage)
+		msg := fmt.Sprintf("%s : %s", err.Error(), jsonFile)
+		fmt.Fprint(os.Stderr, msg)
+		log.Fatal(msg)
 	}
 
 	log.Debugf("Read a task from %s:", jsonFile)

--- a/src/JSONHandler.go
+++ b/src/JSONHandler.go
@@ -123,7 +123,6 @@ func removeOldOutput(dir string, maxToKeep int) {
 			abs := path.Join(dir, name)
 			log.Infoln("removing old output " + abs)
 			if err := os.Remove(abs); err != nil {
-				fmt.Println("removing old output " + abs + " failed")
 				log.Errorln("removing old output " + abs + " failed")
 			}
 		}

--- a/src/JSONHandler.go
+++ b/src/JSONHandler.go
@@ -23,7 +23,6 @@ type JSONReport struct {
 // PlanetWrapper ...
 type PlanetWrapper struct {
 	ID        string `json:"id"`
-	Name      string `json:"name"`
 	Valid     bool   `json:"valid"`
 	Output    string `json:"output"`
 	Errored   bool   `json:"errored"`
@@ -48,7 +47,6 @@ func writeResultAsJSON(planets []Planet, opts *Opts, writer io.Writer) {
 	for i, planet := range planets {
 		wrapper := PlanetWrapper{
 			ID:      planet.id,
-			Name:    planet.name,
 			Output:  planet.outputStruct.output,
 			Errored: planet.outputStruct.errored,
 			// RFC3339 is a subset of ISO 8601

--- a/src/JSONHandler.go
+++ b/src/JSONHandler.go
@@ -89,6 +89,8 @@ func createJSONReport(options map[string]string, planets []Planet, opts *Opts) {
 	if err != nil {
 		log.Fatalf("Could not create json output for the job %s", opts.String())
 	}
+
+	removeOldOutput(folders, opts.MaxToKeep)
 	now := time.Now()
 	format := "%d-%02d-%02dT%02d_%02d_%02d"
 	stamp := fmt.Sprintf(format, now.Year(), now.Month(), now.Day(),
@@ -102,6 +104,30 @@ func createJSONReport(options map[string]string, planets []Planet, opts *Opts) {
 		return
 	}
 	log.Fatalf("Could not create json output for the job %s", basename)
+}
+
+func removeOldOutput(dir string, maxToKeep int) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		log.Fatalf("Could not read files in folder %s", dir)
+	}
+
+	total := len(files)
+
+	if total > maxToKeep {
+		diff := total - maxToKeep
+		toDelete := files[:diff]
+
+		for _, file := range toDelete {
+			name := file.Name()
+			abs := path.Join(dir, name)
+			log.Infoln("removing old output " + abs)
+			if err := os.Remove(abs); err != nil {
+				fmt.Println("removing old output " + abs + " failed")
+				log.Errorln("removing old output " + abs + " failed")
+			}
+		}
+	}
 }
 
 // creates a task from a json file

--- a/src/JSONHandler_test.go
+++ b/src/JSONHandler_test.go
@@ -83,34 +83,10 @@ func TestWriteResultAsJSON(t *testing.T) {
 			if err := json.Unmarshal(bytes, &allInOne); err != nil {
 				t.Fail()
 			} else {
-				if allInOne.Planets[0].ID != planet.id {
-					t.Fail()
-				}
-				if allInOne.Planets[0].Name != planet.name {
-					t.Fail()
-				}
-				if allInOne.Planets[0].User != planet.user {
-					t.Fail()
-				}
-				if allInOne.Planets[0].Host != planet.host {
-					t.Fail()
-				}
-				if allInOne.Planets[0].PlanetType != planet.planetType {
-					t.Fail()
-				}
-				if allInOne.Planets[0].DbID != planet.dbID {
-					t.Fail()
-				}
-				if allInOne.Planets[0].Valid != planet.valid {
-					t.Fail()
-				}
-				if allInOne.Planets[0].Output != planet.outputStruct.output {
-					t.Fail()
-				}
-				if allInOne.Planets[0].Index != planet.outputStruct.position {
-					t.Fail()
-				}
-				if allInOne.Planets[0].Errored != planet.outputStruct.errored {
+				if allInOne.Planets[0].ID != planet.id ||
+					allInOne.Planets[0].Name != planet.name ||
+					allInOne.Planets[0].Output != planet.outputStruct.output ||
+					allInOne.Planets[0].Errored != planet.outputStruct.errored {
 					t.Fail()
 				}
 			}
@@ -127,7 +103,7 @@ func TestWriteResultAsJSON(t *testing.T) {
 // func createJSONReport(options map[string]string, planets []Planet, opts *Opts)
 func TestCreateJSONReport(t *testing.T) {
 	// Setup
-	jobFile := "job.js"
+	jobFile := "job"
 	backup := os.Getenv("ORBIT_HOME")
 	os.Setenv("ORBIT_HOME", os.TempDir())
 
@@ -168,23 +144,17 @@ func TestCreateJSONReport(t *testing.T) {
 	jobName := strings.Split(options["job_name"], ".")[0]
 	// ${ORBIT_HOME/cron_jobs/job/${timestamp_in_iso8601 with : replaced with _ }.json
 	outputFolder := path.Join(options["orbit_home"], options["output"], jobName)
-	fileToWrite := findLatest(outputFolder)
-	fmt.Printf("Attempting to unmarshal JSONReport from %s\n", fileToWrite)
+	latestReport := findLatest(outputFolder)
+	fmt.Printf("Attempting to unmarshal JSONReport from %s\n", latestReport)
 	var bytes []byte
 	var err error
-	if bytes, err = ioutil.ReadFile(fileToWrite); err == nil {
+	if bytes, err = ioutil.ReadFile(latestReport); err == nil {
 		report := JSONReport{}
 		if err = json.Unmarshal(bytes, &report); err == nil {
 			wrapper := report.Planets[0]
 			if wrapper.ID != planet.id ||
 				wrapper.Name != planet.name ||
-				wrapper.User != planet.user ||
-				wrapper.Host != planet.host ||
-				wrapper.PlanetType != planet.planetType ||
-				wrapper.DbID != planet.dbID ||
-				wrapper.Valid != planet.valid ||
 				wrapper.Output != planet.outputStruct.output ||
-				wrapper.Index != planet.outputStruct.position ||
 				wrapper.Errored != planet.outputStruct.errored {
 				fmt.Fprintln(os.Stderr, "Unmarshalled object contains wrong values.")
 				t.Fail()

--- a/src/JSONHandler_test.go
+++ b/src/JSONHandler_test.go
@@ -156,10 +156,11 @@ func TestCreateJSONReport(t *testing.T) {
 
 	// "-j=/tmp/job.js", "-t=\"perlver_template\"", "-p", "-d=true", "app"
 	opts := Opts{
-		Template: "perlver_template",
-		Pretty:   true,
-		Debug:    true,
-		Planets:  []string{"app"},
+		Template:  "perlver_template",
+		Pretty:    true,
+		Debug:     true,
+		MaxToKeep: 2,
+		Planets:   []string{"app"},
 	}
 
 	createJSONReport(options, planets, &opts)

--- a/src/JSONHandler_test.go
+++ b/src/JSONHandler_test.go
@@ -84,7 +84,6 @@ func TestWriteResultAsJSON(t *testing.T) {
 				t.Fail()
 			} else {
 				if allInOne.Planets[0].ID != planet.id ||
-					allInOne.Planets[0].Name != planet.name ||
 					allInOne.Planets[0].Output != planet.outputStruct.output ||
 					allInOne.Planets[0].Errored != planet.outputStruct.errored {
 					t.Fail()
@@ -153,7 +152,6 @@ func TestCreateJSONReport(t *testing.T) {
 		if err = json.Unmarshal(bytes, &report); err == nil {
 			wrapper := report.Planets[0]
 			if wrapper.ID != planet.id ||
-				wrapper.Name != planet.name ||
 				wrapper.Output != planet.outputStruct.output ||
 				wrapper.Errored != planet.outputStruct.errored {
 				fmt.Fprintln(os.Stderr, "Unmarshalled object contains wrong values.")

--- a/src/OptParser.go
+++ b/src/OptParser.go
@@ -19,7 +19,7 @@ type Opts struct {
 	Load       bool     `json:"load"`
 	Pretty     bool     `json:"pretty"`
 	Version    bool     `json:"version"`
-	SaveReport bool     `json:"save_report"`
+	MaxToKeep  int      `json:"max_to_keep"`
 	Command    string   `json:"command"`
 	ScriptName string   `json:"scriptName"`
 	Template   string   `json:"template"`
@@ -36,7 +36,7 @@ func (opts *Opts) String() string {
 	Load: %t
 	Pretty: %t
 	Version: %t
-	SaveReport: %t
+	MaxToKeep: %d
 	Command: %s
 	ScriptName: %s
 	Template : %s
@@ -50,7 +50,7 @@ func (opts *Opts) String() string {
 		opts.Load,
 		opts.Pretty,
 		opts.Version,
-		opts.SaveReport,
+		opts.MaxToKeep,
 		opts.Command,
 		opts.ScriptName,
 		opts.Template,

--- a/src/OptParser_test.go
+++ b/src/OptParser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func setupOptParserTest() (string, error) {
-	toUnMarshall := "job.js"
+	toUnMarshall := "job.json"
 	// "-s=\"showver.sh\"", "-t=\"useless_template\"", "-d", "-p", "app"
 	json := `{
   "debug"      : true,
@@ -24,7 +24,8 @@ func setupOptParserTest() (string, error) {
 }
 `
 	data := []byte(json)
-	absPath := path.Join(os.TempDir(), toUnMarshall)
+	os.Mkdir(path.Join(os.TempDir(), "jobs"), 0744)
+	absPath := path.Join(os.TempDir(), "jobs", toUnMarshall)
 
 	if err := ioutil.WriteFile(absPath, data, 0644); err != nil {
 		return "", err
@@ -36,6 +37,10 @@ func TestCreateTaskFromJobFile(t *testing.T) {
 	fmt.Println("starting Test for CreateTaskFromJobFile")
 	var absPath string
 	var err error
+
+	backup := os.Getenv("ORBIT_HOME")
+	os.Setenv("ORBIT_HOME", os.TempDir())
+
 	if absPath, err = setupOptParserTest(); err != nil {
 		t.Fail()
 	}
@@ -46,8 +51,13 @@ func TestCreateTaskFromJobFile(t *testing.T) {
 		fmt.Fprintf(os.Stderr, "parsed from json: %v", opts)
 		t.Fail()
 	}
-	// tearDownOptParserTest(absPath)
+
 	fmt.Println("ending Test for CreateTaskFromJobFile")
+
+	defer func() {
+		os.Setenv("ORBIT_HOME", backup)
+		tearDownOptParserTest(absPath)
+	}()
 }
 
 func tearDownOptParserTest(absPath string) {

--- a/src/ski.go
+++ b/src/ski.go
@@ -10,7 +10,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-var help, pretty, debug, load, _version, saveReport bool
+var help, pretty, debug, load, _version bool
+var maxToKeep int
 var jobFile, logFile, template, scriptName, command string
 
 func main() {
@@ -99,7 +100,7 @@ func parseOptions() Opts {
 	flag.BoolVar(&debug, "d", false, "verbose")
 	flag.BoolVar(&load, "l", false, "ssh profile loading")
 	flag.BoolVar(&_version, "v", false, "version")
-	flag.BoolVar(&saveReport, "js", false, "if the summary should be saved in json format. Used with the job flag")
+	flag.IntVar(&maxToKeep, "js", 2, "maximum number of outputs to keep per job")
 	flag.StringVar(&jobFile, "j", "", "path to a json file with a task description")
 	flag.StringVar(&logFile, "logfile", "ski.log", "path to a file for logging")
 	flag.StringVar(&template, "t", "", "filename of template")
@@ -120,7 +121,7 @@ func parseOptions() Opts {
 		Debug:      debug,
 		Load:       load,
 		Version:    _version,
-		SaveReport: saveReport,
+		MaxToKeep:  maxToKeep,
 		Template:   template,
 		ScriptName: scriptName,
 		Command:    command,


### PR DESCRIPTION
Closes #43 

Plz merge after the PR for the Ticket #44.

- -j='my-job' instead of -j='my_job.json'
- Timestamp is in the planet output in UTC as a value for a new field called CreatedAt, since I will probalbly need it on the client for sorting. meta is for communication between client and server so the timestamp doesn't belong there.
- id, name, valid, errored, output fields are left. I may need the errored and valid boolean flags for highlighting a row in a table for a planet where the execution of a certain commaned failed. The field name is user friendly, so I thought it doesn't hurt to keep it.
- error output: not done in this PR since the information is already gone by the time I need to create the report. May need an extensive refactoring of the executor. Therefore I would like to do it in a new ticket.